### PR TITLE
Switch to CSS plugin registration for DaisyUI

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,9 +6,6 @@ module.exports = {
     theme: {
       extend: {},
     },
-    plugins: [require("daisyui")],
-    daisyui: {
-      themes: false, // desactiva todos los temas por defecto
-    },
+    plugins: [],
   };
   


### PR DESCRIPTION
## Summary
- rely on CSS `@plugin` directives for DaisyUI instead of Tailwind config

## Testing
- `npx ng build --configuration development`
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: Module './app' has no exported member 'App')*

------
https://chatgpt.com/codex/tasks/task_e_685adc67c9b4832ab857908f6694eae8