### PR TITLE
Add interactive UI components

### DIFF
--- a/src/app/home/pages/home.page.ts
+++ b/src/app/home/pages/home.page.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
       <p class="text-base font-sans max-w-md mx-auto mb-8">
         Descubre un nombre simbólico y emocionalmente conectado con tu energía.
       </p>
-      <a routerLink="/test" class="btn btn-primary">Comenzar el Test</a>
+      <a routerLink="/test" class="btn btn-primary transition-all hover:scale-105 focus-visible:ring">Comenzar el Test</a>
     </section>
   `,
 })

--- a/src/app/layout/components/header.component.ts
+++ b/src/app/layout/components/header.component.ts
@@ -11,7 +11,7 @@ import { ThemeService } from '../../theme/services/theme.service';
         <a routerLink="/" class="text-xl font-serif tracking-wide">Nomia 🌿</a>
       </div>
       <div class="flex-none gap-2">
-        <button class="btn btn-ghost" (click)="toggleTheme()">
+        <button class="btn btn-ghost transition-all hover:scale-105 focus-visible:ring" (click)="toggleTheme()">
             @if (isDark) {
             <span class="material-icons">dark_mode</span>
             } @else {

--- a/src/app/pay/pages/payment-redirect.page.ts
+++ b/src/app/pay/pages/payment-redirect.page.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
     <section class="py-16 px-4 text-center">
       <h2 class="text-3xl font-serif mb-4">Procesando tu pago</h2>
       <p class="text-base font-sans mb-6">Estamos confirmando tu pago para mostrar tu resultado premium.</p>
-      <progress class="progress progress-primary w-56 mx-auto"></progress>
+      <progress class="progress progress-primary w-56 mx-auto transition-colors"></progress>
     </section>
   `,
 })

--- a/src/app/result/pages/result.page.ts
+++ b/src/app/result/pages/result.page.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
     <section class="py-16 px-4 text-center">
       <h2 class="text-3xl font-serif mb-4">Tu nombre simbólico</h2>
       <p class="text-base font-sans mb-6">Aquí verás el nombre que nació de tu energía emocional.</p>
-      <div class="border border-base-300 rounded-lg p-6 shadow-md">
+      <div class="ui-natal-card transition-colors">
         <p class="text-lg font-serif italic">[Nombre generado o curado]</p>
       </div>
     </section>

--- a/src/app/shared/components/alert.component.ts
+++ b/src/app/shared/components/alert.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import { NgIf, NgClass } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'ui-alert',
+  imports: [NgIf, NgClass],
+  template: `
+    <div *ngIf="visible" class="alert transition-colors" [ngClass]="'alert-' + type">
+      <span *ngIf="icon" class="material-icons mr-2">{{ icon }}</span>
+      <span class="flex-1"><ng-content></ng-content></span>
+      <button *ngIf="closable" type="button" aria-label="Cerrar" class="btn btn-sm btn-circle btn-ghost ml-2" (click)="visible = false">
+        <span class="material-icons text-base-content text-sm">close</span>
+      </button>
+    </div>
+  `,
+})
+export class AlertComponent {
+  @Input() type: 'info' | 'success' | 'warning' | 'error' = 'info';
+  @Input() icon?: string;
+  @Input() closable = false;
+  visible = true;
+}

--- a/src/app/shared/components/checkbox.component.ts
+++ b/src/app/shared/components/checkbox.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  standalone: true,
+  selector: 'ui-checkbox',
+  imports: [FormsModule],
+  template: `
+    <label class="label cursor-pointer gap-2">
+      <input type="checkbox" class="checkbox transition-colors" [(ngModel)]="checked" />
+      <span><ng-content></ng-content></span>
+    </label>
+  `,
+})
+export class CheckboxComponent {
+  @Input() checked = false;
+}

--- a/src/app/shared/components/index.ts
+++ b/src/app/shared/components/index.ts
@@ -1,0 +1,5 @@
+export * from './alert.component';
+export * from './checkbox.component';
+export * from './radio.component';
+export * from './toggle.component';
+export * from './progress.component';

--- a/src/app/shared/components/progress.component.ts
+++ b/src/app/shared/components/progress.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { NgClass } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'ui-progress',
+  imports: [NgClass],
+  template: `
+    <progress class="progress w-full transition-colors" [ngClass]="'progress-' + color" [value]="value" [max]="max"></progress>
+  `,
+})
+export class ProgressComponent {
+  @Input() color: 'primary' | 'secondary' | 'accent' | 'info' | 'success' | 'warning' | 'error' = 'primary';
+  @Input() value = 0;
+  @Input() max = 100;
+}

--- a/src/app/shared/components/radio.component.ts
+++ b/src/app/shared/components/radio.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  standalone: true,
+  selector: 'ui-radio',
+  imports: [FormsModule],
+  template: `
+    <label class="label cursor-pointer gap-2">
+      <input type="radio" class="radio transition-colors" [name]="name" [(ngModel)]="model" [value]="value" />
+      <span><ng-content></ng-content></span>
+    </label>
+  `,
+})
+export class RadioComponent {
+  @Input() name = '';
+  @Input() value: any;
+  @Input() model: any;
+}

--- a/src/app/shared/components/toggle.component.ts
+++ b/src/app/shared/components/toggle.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  standalone: true,
+  selector: 'ui-toggle',
+  imports: [FormsModule],
+  template: `
+    <label class="cursor-pointer label gap-2">
+      <input type="checkbox" class="toggle transition-colors" [(ngModel)]="checked" />
+      <span><ng-content></ng-content></span>
+    </label>
+  `,
+})
+export class ToggleComponent {
+  @Input() checked = false;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -143,3 +143,9 @@
   📌 Ambas paletas cumplen accesibilidad WCAG 2.1 (contraste ≥ 4.5:1).
   📌 Cada variable está pensada para fluir visual y emocionalmente con la experiencia del test y resultado simbólico.
 */
+
+@layer components {
+  .ui-natal-card {
+    @apply border border-base-300 rounded-lg p-6 shadow-md bg-gradient-to-br from-primary/10 via-secondary/10 to-base-100 dark:from-fuchsia-900 dark:via-purple-800 dark:to-base-200;
+  }
+}


### PR DESCRIPTION
## Summary
- add button transitions on home and header
- style natal card with gradients
- show gradient natal card in the result page
- tweak payment progress bar transitions
- implement `ui-alert` with optional icon and close button
- add checkbox, radio, toggle and progress shared components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aec7b3258832aa28e09d1c20105dd