### PR TITLE
Fix natal card component theme support

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,21 +1,21 @@
 import { TestBed } from '@angular/core/testing';
-import { App } from './app';
+import { AppComponent } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      imports: [AppComponent],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Hello, nomia');

--- a/src/app/shared/components/natal-card.component.ts
+++ b/src/app/shared/components/natal-card.component.ts
@@ -4,9 +4,7 @@ import { Component, Input } from '@angular/core';
   selector: 'ui-natal-card',
   standalone: true,
   template: `
-    <div
-      class="card bg-gradient-to-br from-[oklch(98%_0.02_40)] to-[oklch(95%_0.03_280)] text-center shadow-md p-6 rounded-xl"
-    >
+    <div class="ui-natal-card card text-center transition-colors">
       <h2 class="text-3xl font-serif mb-2">{{ name }}</h2>
       <div class="text-base mb-4">
         <ng-content></ng-content>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,16 @@
 /** @type {import('tailwindcss').Config} */
+const daisyui = require('daisyui');
+
 module.exports = {
-    content: [
-      "./src/**/*.{html,ts}",
-    ],
-    theme: {
-      extend: {},
-    },
-    plugins: [],
-  };
+  content: [
+    "./src/**/*.{html,ts}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [daisyui],
+  daisyui: {
+    themes: ["nomialight", "nomiadark"],
+  },
+};
   


### PR DESCRIPTION
## Summary
- use DaisyUI plugin and custom themes in `tailwind.config.js`
- hook `ui-natal-card` component to DaisyUI classes so themes apply
- fix unit tests to import `AppComponent`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_685b137d1a44832ab89206e748e48360