### PR TITLE
Create landing sections

### DIFF
--- a/src/app/home/components/benefits-section.component.ts
+++ b/src/app/home/components/benefits-section.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-benefits-section',
+  template: `
+    <section class="py-16 px-6">
+      <h2 class="text-2xl font-serif text-center mb-8">Beneficios</h2>
+      <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 max-w-4xl mx-auto">
+        <div class="text-center">
+          <span class="material-icons text-accent text-3xl mb-2">flare</span>
+          <p class="font-semibold">Nombre con propósito</p>
+        </div>
+        <div class="text-center">
+          <span class="material-icons text-accent text-3xl mb-2">visibility</span>
+          <p class="font-semibold">Significado oculto</p>
+        </div>
+        <div class="text-center">
+          <span class="material-icons text-accent text-3xl mb-2">favorite</span>
+          <p class="font-semibold">Memoria emocional</p>
+        </div>
+      </div>
+    </section>
+  `,
+})
+export class BenefitsSectionComponent {}

--- a/src/app/home/components/hero-section.component.ts
+++ b/src/app/home/components/hero-section.component.ts
@@ -1,0 +1,29 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { PrimaryButtonComponent } from '../../shared/components';
+
+@Component({
+  standalone: true,
+  selector: 'app-hero-section',
+  imports: [RouterModule, PrimaryButtonComponent],
+  template: `
+    <section
+      class="relative overflow-hidden text-center px-6 py-24 bg-gradient-to-br from-[oklch(98%_0.02_40)] to-[oklch(95%_0.03_280)] transition-all duration-700"
+      [class.opacity-0]="!loaded" [class.translate-y-4]="!loaded">
+      <div class="relative z-10 max-w-2xl mx-auto">
+        <h1 class="text-4xl md:text-5xl font-serif mb-4">El alma ya conoce su nombre</h1>
+        <p class="text-base md:text-lg mb-8">Descubre el nombre que resuena con tu energía emocional y espiritual</p>
+        <a routerLink="/test" class="btn btn-primary transition-shadow duration-700" [class.shadow-lg]="loaded">Comenzar el Test</a>
+      </div>
+      <svg aria-hidden="true" viewBox="0 0 200 200" class="absolute opacity-20 w-56 h-56 -right-20 -bottom-20 text-secondary">
+        <circle cx="100" cy="100" r="80" fill="currentColor" />
+      </svg>
+    </section>
+  `,
+})
+export class HeroSectionComponent implements AfterViewInit {
+  loaded = false;
+  ngAfterViewInit() {
+    setTimeout(() => (this.loaded = true));
+  }
+}

--- a/src/app/home/components/premium-card-preview.component.ts
+++ b/src/app/home/components/premium-card-preview.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { NatalCardComponent, SecondaryButtonComponent } from '../../shared/components';
+
+@Component({
+  standalone: true,
+  selector: 'app-premium-card-preview',
+  imports: [RouterModule, NatalCardComponent, SecondaryButtonComponent],
+  template: `
+    <section class="py-16 px-6 text-center">
+      <div class="max-w-md mx-auto">
+        <ui-natal-card name="Tu Nombre">
+          <p class="text-lg font-serif italic">Tu carta personalizada te espera…</p>
+        </ui-natal-card>
+        <a routerLink="/test" class="btn btn-secondary mt-6">Descubre tu nombre</a>
+      </div>
+    </section>
+  `,
+})
+export class PremiumCardPreviewComponent {}

--- a/src/app/home/components/steps-section.component.ts
+++ b/src/app/home/components/steps-section.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-steps-section',
+  template: `
+    <section class="py-16 px-6">
+      <h2 class="text-2xl font-serif text-center mb-8">Cómo funciona</h2>
+      <div class="grid gap-6 md:grid-cols-3">
+        <div class="bg-base-200 rounded-xl p-6 text-center">
+          <span class="material-icons text-4xl text-secondary mb-2">psychology</span>
+          <h3 class="font-serif text-lg mb-1">Responde nuestro test emocional</h3>
+          <p class="text-sm opacity-80">Conecta con tus emociones en minutos.</p>
+        </div>
+        <div class="bg-base-200 rounded-xl p-6 text-center">
+          <span class="material-icons text-4xl text-secondary mb-2">auto_stories</span>
+          <h3 class="font-serif text-lg mb-1">Recibe tu nombre simbólico</h3>
+          <p class="text-sm opacity-80">Te enviaremos su significado oculto.</p>
+        </div>
+        <div class="bg-base-200 rounded-xl p-6 text-center">
+          <span class="material-icons text-4xl text-secondary mb-2">share</span>
+          <h3 class="font-serif text-lg mb-1">Guárdalo o compártelo</h3>
+          <p class="text-sm opacity-80">Llévalo siempre contigo.</p>
+        </div>
+      </div>
+    </section>
+  `,
+})
+export class StepsSectionComponent {}

--- a/src/app/home/components/testimonial-section.component.ts
+++ b/src/app/home/components/testimonial-section.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-testimonial-section',
+  template: `
+    <section class="py-16 px-6">
+      <div class="max-w-md mx-auto bg-base-200 rounded-xl p-6 text-center">
+        <div class="w-16 h-16 mx-auto mb-4 bg-secondary rounded-full grid place-items-center">
+          <span class="material-icons text-base-100 text-3xl">star</span>
+        </div>
+        <p class="italic mb-2">“Cuando vi el nombre, sentí que era exactamente lo que buscaba. Me emocionó profundamente.”</p>
+        <p class="font-serif font-semibold">Luna Mística</p>
+      </div>
+    </section>
+  `,
+})
+export class TestimonialSectionComponent {}

--- a/src/app/home/pages/home.page.ts
+++ b/src/app/home/pages/home.page.ts
@@ -1,72 +1,26 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import {
-  PrimaryButtonComponent,
-  SecondaryButtonComponent,
-  GhostButtonComponent,
-  TextInputComponent,
-  CheckboxComponent,
-  RadioButtonComponent,
-  ToggleSwitchComponent,
-  CardComponent,
-  NatalCardComponent,
-  AlertComponent,
-  ProgressBarComponent,
-  StepperComponent,
-} from '../../shared/components';
+import { HeroSectionComponent } from '../components/hero-section.component';
+import { StepsSectionComponent } from '../components/steps-section.component';
+import { BenefitsSectionComponent } from '../components/benefits-section.component';
+import { TestimonialSectionComponent } from '../components/testimonial-section.component';
+import { PremiumCardPreviewComponent } from '../components/premium-card-preview.component';
 
 @Component({
   standalone: true,
   selector: 'app-home-page',
   imports: [
-    RouterModule,
-    PrimaryButtonComponent,
-    SecondaryButtonComponent,
-    GhostButtonComponent,
-    TextInputComponent,
-    CheckboxComponent,
-    RadioButtonComponent,
-    ToggleSwitchComponent,
-    CardComponent,
-    NatalCardComponent,
-    AlertComponent,
-    ProgressBarComponent,
-    StepperComponent,
+    HeroSectionComponent,
+    StepsSectionComponent,
+    BenefitsSectionComponent,
+    TestimonialSectionComponent,
+    PremiumCardPreviewComponent,
   ],
   template: `
-    <section class="text-center py-20 px-6">
-      <h1 class="text-4xl font-serif mb-4">El alma ya conoce su nombre</h1>
-      <p class="text-base font-sans max-w-md mx-auto mb-8">
-        Descubre un nombre simbólico y emocionalmente conectado con tu energía.
-      </p>
-      <a routerLink="/test" class="btn btn-primary transition-all hover:scale-105 focus-visible:ring">Comenzar el Test</a>
-    </section>
-
-    <section class="max-w-2xl mx-auto p-6 grid gap-4">
-      <h2 class="text-2xl font-serif mb-2">Demo de componentes</h2>
-
-      <div class="flex gap-2">
-        <ui-primary-button>Primario</ui-primary-button>
-        <ui-secondary-button>Secundario</ui-secondary-button>
-        <ui-ghost-button>Ghost</ui-ghost-button>
-      </div>
-
-      <ui-text-input placeholder="Escribe algo"></ui-text-input>
-      <ui-checkbox>Selecciona</ui-checkbox>
-      <div class="flex gap-2">
-        <ui-radio-button name="demo" value="1" [checked]="true">Opción 1</ui-radio-button>
-        <ui-radio-button name="demo" value="2">Opción 2</ui-radio-button>
-      </div>
-      <ui-toggle-switch>Activar</ui-toggle-switch>
-
-      <ui-card>Una tarjeta sencilla</ui-card>
-      <ui-natal-card name="Aura">Nombre místico sugerido</ui-natal-card>
-
-      <ui-alert type="info">Este es un mensaje informativo.</ui-alert>
-
-      <ui-progress-bar [value]="40" [max]="100"></ui-progress-bar>
-      <ui-stepper [steps]="['Uno', 'Dos', 'Tres']" [active]="1"></ui-stepper>
-    </section>
+    <app-hero-section />
+    <app-steps-section />
+    <app-benefits-section />
+    <app-testimonial-section />
+    <app-premium-card-preview />
   `,
 })
 export class HomePage {}


### PR DESCRIPTION
## Summary
- add hero, steps, benefits, testimonial and premium preview sections
- simplify home page to use new landing components

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685b2d508b54832abcbeaee72852bb98