### PR TITLE
Add splash screen component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -112,5 +112,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,2 @@
-<router-outlet />
+<app-splash-screen *ngIf="showSplash"></app-splash-screen>
+<router-outlet *ngIf="!showSplash"></router-outlet>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,15 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { SplashScreenComponent } from './splash-screen/splash-screen';
 import { ThemeService } from './theme/services/theme.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, SplashScreenComponent],
   templateUrl: './app.html',
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
+  showSplash = true;
+
   constructor(private theme: ThemeService) {
     this.theme.loadSavedTheme();
+  }
+
+  ngOnInit() {
+    setTimeout(() => this.hideSplash(), 2000);
+  }
+
+  hideSplash() {
+    const splash = document.querySelector('app-splash-screen');
+    if (splash) {
+      splash.classList.add('fade-out');
+      setTimeout(() => (this.showSplash = false), 700);
+    } else {
+      this.showSplash = false;
+    }
   }
 }

--- a/src/app/splash-screen/splash-screen.css
+++ b/src/app/splash-screen/splash-screen.css
@@ -1,0 +1,8 @@
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.fade-out {
+  animation: fadeOut 0.7s ease-out forwards;
+}

--- a/src/app/splash-screen/splash-screen.html
+++ b/src/app/splash-screen/splash-screen.html
@@ -1,0 +1,20 @@
+<div
+  class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-base-100 text-base-content"
+  data-theme="nomialight"
+>
+  <div class="absolute inset-0 flex items-center justify-center">
+    <div class="bg-accent/10 rounded-full w-64 h-64"></div>
+  </div>
+
+  <img
+    src="/assets/img/LogoParaHeader.webp"
+    alt="Logo Nomia"
+    class="relative w-32 md:w-40 lg:w-48 mb-4"
+  />
+
+  <p class="relative text-xl md:text-2xl font-light italic text-center max-w-xs px-4">
+    El alma ya conoce su nombre
+  </p>
+
+  <div class="mt-6 w-6 h-6 rounded-full border-4 border-t-primary border-gray-300 animate-spin"></div>
+</div>

--- a/src/app/splash-screen/splash-screen.ts
+++ b/src/app/splash-screen/splash-screen.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-splash-screen',
+  standalone: true,
+  templateUrl: './splash-screen.html',
+  styleUrls: ['./splash-screen.css'],
+  imports: [],
+})
+export class SplashScreenComponent {}


### PR DESCRIPTION
## Summary
- create `SplashScreenComponent`
- add fade out animation styles
- force Nomia light theme on splash screen
- display splash screen before router outlet
- disable Angular analytics

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685b6bd7885c832abade3fec7e663800