### PR TITLE
Add theme handling and dark mode toggle

### DIFF
--- a/src/app/theme/services/theme.service.ts
+++ b/src/app/theme/services/theme.service.ts
@@ -17,5 +17,6 @@ export class ThemeService {
 
   private applyTheme(theme: 'nomialight' | 'nomiadark') {
     document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.classList.toggle('dark', theme === 'nomiadark');
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,13 @@
     <meta charset="utf-8" />
     <title>Nomia 🌿</title>
     <base href="/" />
+    <script>
+      const saved = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = saved ?? (prefersDark ? 'nomiadark' : 'nomialight');
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.classList.toggle('dark', theme === 'nomiadark');
+    </script>
 
     <!-- Responsive -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
   content: [
     "./src/**/*.{html,ts}",
   ],
+  darkMode: ['class', '[data-theme="nomiadark"]'],
   theme: {
     extend: {
       backgroundImage: {
@@ -15,7 +16,9 @@ module.exports = {
   },
   plugins: [daisyui],
   daisyui: {
-    themes: ["nomialight", "nomiadark"],
+    themes: ['nomialight', 'nomiadark'],
+    darkTheme: 'nomiadark',
+    defaultTheme: 'nomialight',
   },
 };
   


### PR DESCRIPTION
## Summary
- initialize theme early in `index.html`
- configure Tailwind to react to `[data-theme="nomiadark"]`
- toggle the `'dark'` class when applying theme in `ThemeService`

## Testing
- `npm install`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685b8fefd180832a980da9dc23a88bfb