### PR TITLE
Add animations to splash screen

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    setTimeout(() => this.hideSplash(), 2000);
+    setTimeout(() => this.hideSplash(), 4500);
   }
 
   hideSplash() {

--- a/src/app/splash-screen/splash-screen.css
+++ b/src/app/splash-screen/splash-screen.css
@@ -6,3 +6,64 @@
 .fade-out {
   animation: fadeOut 0.7s ease-out forwards;
 }
+
+@keyframes circleGrow {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+.circle-grow {
+  transform-origin: center;
+  animation: circleGrow 0.7s ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.logo-fade-in {
+  opacity: 0;
+  animation: fadeIn 0.7s ease-out forwards;
+  animation-delay: 0.7s;
+}
+
+.spinner-fade-in {
+  opacity: 0;
+  animation: fadeIn 0.7s ease-out forwards;
+  animation-delay: 1.4s;
+}
+
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 27ch;
+  }
+}
+
+@keyframes blink {
+  50% {
+    border-color: transparent;
+  }
+}
+
+.typing {
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid currentColor;
+  width: 0;
+  animation:
+    typing 2s steps(27, end) forwards,
+    blink 0.75s step-end infinite;
+  animation-delay: 2.1s;
+}

--- a/src/app/splash-screen/splash-screen.html
+++ b/src/app/splash-screen/splash-screen.html
@@ -3,22 +3,22 @@
   [attr.data-theme]="dataTheme"
 >
   <!-- Círculo relativo para posicionamiento interno -->
-  <div class="bg-accent/10 rounded-full w-64 h-64 flex items-center justify-center relative">
+  <div class="bg-accent/10 rounded-full w-64 h-64 flex items-center justify-center relative circle-grow">
     <!-- Logo centrado -->
     <img
       [src]="logoSrc"
       alt="Logo Nomia"
-      class="w-32 md:w-40 lg:w-48"
+      class="w-32 md:w-40 lg:w-48 opacity-0 logo-fade-in"
     />
 
     <!-- Spinner absoluto: no afecta al flex centering -->
     <div
       #spinner
-      class="absolute bottom-6 left-1/2 transform -translate-x-1/2 w-10 h-10"
+      class="absolute bottom-6 left-1/2 transform -translate-x-1/2 w-10 h-10 opacity-0 spinner-fade-in"
     ></div>
   </div>
 
-  <p class="mt-6 text-xl md:text-2xl font-light italic text-center max-w-xs px-4">
+  <p class="mt-6 text-xl md:text-2xl font-light italic text-center max-w-xs px-4 typing" style="display:inline-block">
     El alma ya conoce su nombre
   </p>
 </div>


### PR DESCRIPTION
## Summary
- animate splash circle grow
- add fade in effects for logo and spinner
- animate tagline with typewriter style
- keep splash screen visible long enough for animations

## Testing
- `npm ci`
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b92244938832a8ffed8affa8e4ad2