### PR TITLE
Add ethereal entry animation after splash

### DIFF
--- a/src/app/home/components/hero-section.component.ts
+++ b/src/app/home/components/hero-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, Inject, DOCUMENT } from '@angular/core';
+import { Component, Inject, DOCUMENT } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { PrimaryButtonComponent } from '../../shared/components';
 
@@ -13,8 +13,6 @@ import { PrimaryButtonComponent } from '../../shared/components';
       [class.bg-hero-dark]="isDark"
       [class.text-base-content]="!isDark"
       [class.text-base-content]="isDark"
-      [class.opacity-0]="!loaded"
-      [class.translate-y-4]="!loaded"
     >
       <div class="relative z-10 max-w-2xl mx-auto">
         <h1 class="text-4xl md:text-5xl font-serif mb-4 text-base-content">
@@ -26,8 +24,6 @@ import { PrimaryButtonComponent } from '../../shared/components';
         <a
           routerLink="/test"
           class="btn btn-primary shadow-md transition-all duration-700 ease-out"
-          [class.opacity-0]="!loaded"
-          [class.translate-y-4]="!loaded"
         >
           <span class="mr-1">✨</span> Comenzar el Test
         </a>
@@ -44,8 +40,7 @@ import { PrimaryButtonComponent } from '../../shared/components';
     </section>
   `,
 })
-export class HeroSectionComponent implements AfterViewInit {
-  loaded = false;
+export class HeroSectionComponent {
 
   /** Declaramos explícitamente la propiedad */
   isDark = false;
@@ -55,12 +50,4 @@ export class HeroSectionComponent implements AfterViewInit {
     this.isDark = this.document.documentElement.classList.contains('dark');
   }
 
-  ngAfterViewInit() {
-    // Tras el render inicial, lanzamos la animación
-    setTimeout(() => {
-      this.loaded = true;
-      // Por si el usuario cambió el theme justo al cargar
-      this.isDark = this.document.documentElement.classList.contains('dark');
-    }, 10);
-  }
 }

--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -7,7 +7,7 @@ import { FooterComponent } from './components/footer.component';
   standalone: true,
   selector: 'app-layout',
   template: `
-    <div class="min-h-screen flex flex-col bg-base-100 text-base-content transition-all duration-300">
+    <div class="min-h-screen flex flex-col bg-base-100 text-base-content transition-all duration-300 animate-ethereal-entry">
       <app-header />
       <main class="flex-1">
         <router-outlet />

--- a/src/styles.css
+++ b/src/styles.css
@@ -165,4 +165,19 @@
   .animate-fade-in {
     animation: fade-in 0.7s ease-out both;
   }
+  @keyframes ethereal-entry {
+    0% {
+      opacity: 0;
+      transform: translateY(2rem) scale(0.98);
+      filter: blur(8px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      filter: blur(0);
+    }
+  }
+  .animate-ethereal-entry {
+    animation: ethereal-entry 1s ease-out both;
+  }
 }


### PR DESCRIPTION
## Summary
- add global `ethereal-entry` animation
- animate layout container when splash screen hides

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9f9968f0832ab22c40b5feed6690