### PR TITLE
Remove motion-safe from layout animation

### DIFF
--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -7,7 +7,7 @@ import { FooterComponent } from './components/footer.component';
   standalone: true,
   selector: 'app-layout',
   template: `
-    <div class="min-h-screen flex flex-col bg-base-100 text-base-content transition-all duration-300 motion-safe:animate-ethereal-entry">
+    <div class="min-h-screen flex flex-col bg-base-100 text-base-content transition-all duration-300 animate-ethereal-entry">
       <app-header />
       <main class="flex-1">
         <router-outlet />


### PR DESCRIPTION
## Summary
- remove `motion-safe:` prefix from layout root div so animation always triggers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ba7930e7c832abc3f897dc4c9324f