### PR TITLE
Implement ritualistic quiz

### DIFF
--- a/src/app/test/components/animated-background.component.ts
+++ b/src/app/test/components/animated-background.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-animated-background',
+  template: `
+    <div
+      class="pointer-events-none fixed inset-0 -z-10 opacity-20 animate-pulse-slow"
+      aria-hidden="true"
+    >
+      <div class="absolute inset-0 bg-gradient-to-br from-accent/20 to-primary/20"></div>
+    </div>
+  `,
+})
+export class AnimatedBackgroundComponent {}

--- a/src/app/test/components/answer-button.component.ts
+++ b/src/app/test/components/answer-button.component.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgClass } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'app-answer-button',
+  imports: [NgClass],
+  template: `
+    <button
+      class="btn btn-outline w-full flex items-center justify-start gap-2 transition-colors"
+      [ngClass]="{
+        'border-primary ring-2 ring-accent': selected
+      }"
+      (click)="choose.emit(optionId)"
+    >
+      <span *ngIf="icon" aria-hidden="true">{{ icon }}</span>
+      <span class="flex-1 text-left">{{ label }}</span>
+    </button>
+  `,
+})
+export class AnswerButtonComponent {
+  @Input() label = '';
+  @Input() optionId = '';
+  @Input() icon?: string;
+  @Input() selected = false;
+  @Output() choose = new EventEmitter<string>();
+}

--- a/src/app/test/components/index.ts
+++ b/src/app/test/components/index.ts
@@ -1,0 +1,6 @@
+export * from './test-header.component';
+export * from './test-progress.component';
+export * from './question-viewer.component';
+export * from './answer-button.component';
+export * from './navigation-buttons.component';
+export * from './animated-background.component';

--- a/src/app/test/components/navigation-buttons.component.ts
+++ b/src/app/test/components/navigation-buttons.component.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { PrimaryButtonComponent, GhostButtonComponent } from '../../shared/components';
+
+@Component({
+  standalone: true,
+  selector: 'app-navigation-buttons',
+  imports: [NgIf, PrimaryButtonComponent, GhostButtonComponent],
+  template: `
+    <div class="flex justify-between mt-6">
+      <ui-ghost-button type="button" (click)="prev.emit()" [disabled]="!canPrev">
+        Anterior
+      </ui-ghost-button>
+      <ui-primary-button type="button" (click)="next.emit()" [disabled]="!canNext">
+        {{ isLast ? 'Finalizar' : 'Siguiente' }}
+      </ui-primary-button>
+    </div>
+  `,
+})
+export class NavigationButtonsComponent {
+  @Input() canPrev = false;
+  @Input() canNext = false;
+  @Input() isLast = false;
+  @Output() prev = new EventEmitter<void>();
+  @Output() next = new EventEmitter<void>();
+}

--- a/src/app/test/components/question-viewer.component.ts
+++ b/src/app/test/components/question-viewer.component.ts
@@ -1,0 +1,46 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { AnswerButtonComponent } from './answer-button.component';
+
+export interface QuestionOption {
+  id: string;
+  label: string;
+  value: number;
+  icon?: string;
+}
+
+export interface Question {
+  id: string;
+  title: string;
+  description?: string;
+  options: QuestionOption[];
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-question-viewer',
+  imports: [NgFor, NgIf, AnswerButtonComponent],
+  template: `
+    <div class="mb-6">
+      <h3 class="text-2xl font-serif mb-2">{{ question?.title }}</h3>
+      <p *ngIf="question?.description" class="text-base mb-4 opacity-80">
+        {{ question?.description }}
+      </p>
+      <div class="space-y-3">
+        <app-answer-button
+          *ngFor="let opt of question?.options"
+          [label]="opt.label"
+          [optionId]="opt.id"
+          [icon]="opt.icon"
+          [selected]="opt.id === selectedOption"
+          (choose)="choose.emit($event)"
+        />
+      </div>
+    </div>
+  `,
+})
+export class QuestionViewerComponent {
+  @Input() question?: Question;
+  @Input() selectedOption?: string;
+  @Output() choose = new EventEmitter<string>();
+}

--- a/src/app/test/components/test-header.component.ts
+++ b/src/app/test/components/test-header.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-test-header',
+  template: `
+    <header class="mb-6 text-center">
+      <h2 class="text-3xl font-serif mb-2">Escucha tu alma...</h2>
+      <p class="text-base font-sans opacity-80">Responde con sinceridad ritual.</p>
+    </header>
+  `,
+})
+export class TestHeaderComponent {}

--- a/src/app/test/components/test-progress.component.ts
+++ b/src/app/test/components/test-progress.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { ProgressBarComponent } from '../../shared/components';
+
+@Component({
+  standalone: true,
+  selector: 'app-test-progress',
+  imports: [ProgressBarComponent],
+  template: `
+    <div class="mb-4">
+      <ui-progress-bar [value]="percent" [max]="100" />
+      <p class="text-sm mt-2 text-center font-sans opacity-80">
+        Paso {{ current }} de {{ total }}
+      </p>
+    </div>
+  `,
+})
+export class TestProgressComponent {
+  @Input() current = 1;
+  @Input() total = 1;
+
+  get percent() {
+    return (this.current / this.total) * 100;
+  }
+}

--- a/src/app/test/services/quiz.service.ts
+++ b/src/app/test/services/quiz.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@angular/core';
+import { Question } from '../components/question-viewer.component';
+
+@Injectable({ providedIn: 'root' })
+export class QuizService {
+  questions: Question[] = [
+    {
+      id: 'q1',
+      title: '¿Qué elemento resuena más contigo?',
+      options: [
+        { id: 'fuego', label: 'Fuego', value: 1, icon: '🔥' },
+        { id: 'agua', label: 'Agua', value: 2, icon: '💧' },
+        { id: 'aire', label: 'Aire', value: 3, icon: '🌬️' },
+        { id: 'tierra', label: 'Tierra', value: 4, icon: '🌱' },
+      ],
+    },
+    {
+      id: 'q2',
+      title: 'Elige el momento del día que prefieres',
+      options: [
+        { id: 'amanecer', label: 'Amanecer', value: 1, icon: '🌅' },
+        { id: 'mediodia', label: 'Mediodía', value: 2, icon: '🌞' },
+        { id: 'atardecer', label: 'Atardecer', value: 3, icon: '🌇' },
+        { id: 'noche', label: 'Noche', value: 4, icon: '🌙' },
+      ],
+    },
+    {
+      id: 'q3',
+      title: '¿Qué flor te inspira más?',
+      options: [
+        { id: 'rosa', label: 'Rosa', value: 1, icon: '🌹' },
+        { id: 'lirio', label: 'Lirio', value: 2, icon: '🌺' },
+        { id: 'jazmin', label: 'Jazmín', value: 3, icon: '🌼' },
+        { id: 'lotus', label: 'Loto', value: 4, icon: '🪷' },
+      ],
+    },
+    {
+      id: 'q4',
+      title: 'Escoge un sonido que armonice tu espíritu',
+      options: [
+        { id: 'olas', label: 'Olas del mar', value: 1, icon: '🌊' },
+        { id: 'lluvia', label: 'Lluvia suave', value: 2, icon: '🌧️' },
+        { id: 'viento', label: 'Viento entre árboles', value: 3, icon: '🍃' },
+        { id: 'campanas', label: 'Campanas tibetanas', value: 4, icon: '🔔' },
+      ],
+    },
+    {
+      id: 'q5',
+      title: '¿Qué cristal llevarías contigo?',
+      options: [
+        { id: 'cuarzo', label: 'Cuarzo', value: 1, icon: '💎' },
+        { id: 'amatista', label: 'Amatista', value: 2, icon: '🔮' },
+        { id: 'obsidiana', label: 'Obsidiana', value: 3, icon: '⚫' },
+        { id: 'jade', label: 'Jade', value: 4, icon: '🟢' },
+      ],
+    },
+    {
+      id: 'q6',
+      title: 'Elige un animal guía',
+      options: [
+        { id: 'lobo', label: 'Lobo', value: 1, icon: '🐺' },
+        { id: 'gato', label: 'Gato', value: 2, icon: '🐱' },
+        { id: 'mariposa', label: 'Mariposa', value: 3, icon: '🦋' },
+        { id: 'lechuza', label: 'Lechuza', value: 4, icon: '🦉' },
+      ],
+    },
+    {
+      id: 'q7',
+      title: '¿Qué aroma calma tu mente?',
+      options: [
+        { id: 'lavanda', label: 'Lavanda', value: 1, icon: '💜' },
+        { id: 'sandalwood', label: 'Sándalo', value: 2, icon: '🪵' },
+        { id: 'jazmin_aroma', label: 'Jazmín', value: 3, icon: '🌸' },
+        { id: 'cedro', label: 'Cedro', value: 4, icon: '🌲' },
+      ],
+    },
+    {
+      id: 'q8',
+      title: 'Elige un camino para recorrer',
+      options: [
+        { id: 'bosque', label: 'Bosque', value: 1, icon: '🌳' },
+        { id: 'montana', label: 'Montaña', value: 2, icon: '⛰️' },
+        { id: 'playa', label: 'Playa', value: 3, icon: '🏖️' },
+        { id: 'desierto', label: 'Desierto', value: 4, icon: '🏜️' },
+      ],
+    },
+    {
+      id: 'q9',
+      title: '¿Cuál estación del año prefieres?',
+      options: [
+        { id: 'primavera', label: 'Primavera', value: 1, icon: '🌷' },
+        { id: 'verano', label: 'Verano', value: 2, icon: '☀️' },
+        { id: 'otono', label: 'Otoño', value: 3, icon: '🍂' },
+        { id: 'invierno', label: 'Invierno', value: 4, icon: '❄️' },
+      ],
+    },
+    {
+      id: 'q10',
+      title: 'Escoge el color que más conecte contigo',
+      options: [
+        { id: 'rojo', label: 'Rojo', value: 1, icon: '❤️' },
+        { id: 'azul', label: 'Azul', value: 2, icon: '💙' },
+        { id: 'verde', label: 'Verde', value: 3, icon: '💚' },
+        { id: 'violeta', label: 'Violeta', value: 4, icon: '💜' },
+      ],
+    },
+  ];
+
+  submitAnswers(answers: Record<string, string>) {
+    // Se podría enviar al backend. Aquí solo registramos en consola.
+    console.log('Enviando quizProfile', answers);
+  }
+}


### PR DESCRIPTION
## Summary
- add quiz components with ceremonial styles
- implement quiz service with 10 symbolic questions
- build a test page guiding the user through the quiz

## Testing
- `npm run build`
- `npm test` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_685baec27c6c832aad6ef169d601d27e