### PR TITLE
Implement Nomia emotional test

### DIFF
--- a/src/app/home/components/hero-section.component.ts
+++ b/src/app/home/components/hero-section.component.ts
@@ -1,11 +1,10 @@
 import { Component, Inject, DOCUMENT } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { PrimaryButtonComponent } from '../../shared/components';
 
 @Component({
   standalone: true,
   selector: 'app-hero-section',
-  imports: [RouterModule, PrimaryButtonComponent],
+  imports: [RouterModule],
   template: `
     <section
       class="relative overflow-hidden text-center px-6 py-24 transition-all duration-700"

--- a/src/app/home/components/premium-card-preview.component.ts
+++ b/src/app/home/components/premium-card-preview.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NatalCardComponent, SecondaryButtonComponent } from '../../shared/components';
+import { NatalCardComponent } from '../../shared/components';
 
 @Component({
   standalone: true,
   selector: 'app-premium-card-preview',
-  imports: [RouterModule, NatalCardComponent, SecondaryButtonComponent],
+  imports: [RouterModule, NatalCardComponent],
   template: `
     <section class="relative py-16 px-6 text-center">
       <div class="absolute -top-10 right-10 w-24 h-24 bg-accent/20 rounded-full blur-2xl"></div>

--- a/src/app/shared/models/quiz-profile.model.ts
+++ b/src/app/shared/models/quiz-profile.model.ts
@@ -1,0 +1,15 @@
+export interface QuizProfile {
+  energia_simbolica: string[];
+  personalidad_proyectada: string[];
+  estilo_sonoro: {
+    longitud: 'corto' | 'largo';
+    vocal_fuerte: boolean;
+    terminacion: 'a' | 'o' | 'otra';
+    silabas: 1 | 2 | 3;
+  };
+  origen_simbolico: string[];
+  valores_deseados: string[];
+  genero_preferido: 'femenino' | 'masculino' | 'neutro' | 'sin_preferencia';
+  tono_poetico: string;
+  epoca_inspiradora: string;
+}

--- a/src/app/test/components/answer-button.component.ts
+++ b/src/app/test/components/answer-button.component.ts
@@ -13,7 +13,9 @@ import { NgClass } from '@angular/common';
       }"
       (click)="choose.emit(optionId)"
     >
-      <span *ngIf="icon" aria-hidden="true">{{ icon }}</span>
+      @if (icon) {
+        <span aria-hidden="true">{{ icon }}</span>
+      }
       <span class="flex-1 text-left">{{ label }}</span>
     </button>
   `,

--- a/src/app/test/components/navigation-buttons.component.ts
+++ b/src/app/test/components/navigation-buttons.component.ts
@@ -1,11 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { NgIf } from '@angular/common';
 import { PrimaryButtonComponent, GhostButtonComponent } from '../../shared/components';
 
 @Component({
   standalone: true,
   selector: 'app-navigation-buttons',
-  imports: [NgIf, PrimaryButtonComponent, GhostButtonComponent],
+  imports: [PrimaryButtonComponent, GhostButtonComponent],
   template: `
     <div class="flex justify-between mt-6">
       <ui-ghost-button type="button" (click)="prev.emit()" [disabled]="!canPrev">

--- a/src/app/test/components/question-viewer.component.ts
+++ b/src/app/test/components/question-viewer.component.ts
@@ -1,46 +1,170 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { NgFor, NgIf } from '@angular/common';
 import { AnswerButtonComponent } from './answer-button.component';
 
 export interface QuestionOption {
   id: string;
   label: string;
-  value: number;
   icon?: string;
+  tonePoetico?: string;
+  epocaInspiradora?: string;
 }
+
+export type QuestionType = 'single' | 'multi' | 'style' | 'combined';
 
 export interface Question {
   id: string;
   title: string;
   description?: string;
-  options: QuestionOption[];
+  type: QuestionType;
+  options?: QuestionOption[];
+  maxSelection?: number;
 }
 
 @Component({
   standalone: true,
   selector: 'app-question-viewer',
-  imports: [NgFor, NgIf, AnswerButtonComponent],
+  imports: [AnswerButtonComponent],
   template: `
     <div class="mb-6">
       <h3 class="text-2xl font-serif mb-2">{{ question?.title }}</h3>
-      <p *ngIf="question?.description" class="text-base mb-4 opacity-80">
-        {{ question?.description }}
-      </p>
-      <div class="space-y-3">
-        <app-answer-button
-          *ngFor="let opt of question?.options"
-          [label]="opt.label"
-          [optionId]="opt.id"
-          [icon]="opt.icon"
-          [selected]="opt.id === selectedOption"
-          (choose)="choose.emit($event)"
-        />
-      </div>
+      @if (question?.description) {
+        <p class="text-base mb-4 opacity-80">{{ question?.description }}</p>
+      }
+      @switch (question?.type) {
+        @case ('single') {
+          <div class="space-y-3">
+            @for (opt of question?.options; track opt.id) {
+              <app-answer-button
+                [label]="opt.label"
+                [optionId]="opt.id"
+                [icon]="opt.icon"
+                [selected]="opt.id === selected"
+                (choose)="choose.emit(opt.id)"
+              />
+            }
+          </div>
+        }
+        @case ('multi') {
+          <div class="space-y-3">
+            @for (opt of question?.options; track opt.id) {
+              <app-answer-button
+                [label]="opt.label"
+                [optionId]="opt.id"
+                [icon]="opt.icon"
+                [selected]="selected?.includes(opt.id)"
+                (choose)="toggleMulti(opt.id)"
+              />
+            }
+          </div>
+        }
+        @case ('style') {
+          <div class="space-y-4">
+            <div>
+              <label class="block mb-1 font-medium">Longitud</label>
+              <select
+                class="select select-bordered w-full"
+                [value]="styleValue.longitud"
+                (change)="updateStyle('longitud', $any($event.target).value)"
+              >
+                <option value="corto">corto</option>
+                <option value="largo">largo</option>
+              </select>
+            </div>
+            <div>
+              <label class="block mb-1 font-medium">Vocal fuerte</label>
+              <select
+                class="select select-bordered w-full"
+                [value]="styleValue.vocal_fuerte"
+                (change)="updateStyle('vocal_fuerte', $any($event.target).value)"
+              >
+                <option value="true">sí</option>
+                <option value="false">no</option>
+              </select>
+            </div>
+            <div>
+              <label class="block mb-1 font-medium">Terminación</label>
+              <select
+                class="select select-bordered w-full"
+                [value]="styleValue.terminacion"
+                (change)="updateStyle('terminacion', $any($event.target).value)"
+              >
+                <option value="a">a</option>
+                <option value="o">o</option>
+                <option value="otra">otra</option>
+              </select>
+            </div>
+            <div>
+              <label class="block mb-1 font-medium">Sílabas</label>
+              <select
+                class="select select-bordered w-full"
+                [value]="styleValue.silabas"
+                (change)="updateStyle('silabas', $any($event.target).value)"
+              >
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+              </select>
+            </div>
+          </div>
+        }
+        @case ('combined') {
+          <div class="space-y-3">
+            @for (opt of question?.options; track opt.id) {
+              <app-answer-button
+                [label]="opt.label"
+                [optionId]="opt.id"
+                [icon]="opt.icon"
+                [selected]="opt.id === selected"
+                (choose)="choose.emit(opt.id)"
+              />
+            }
+          </div>
+        }
+      }
     </div>
   `,
 })
 export class QuestionViewerComponent {
   @Input() question?: Question;
-  @Input() selectedOption?: string;
-  @Output() choose = new EventEmitter<string>();
+  @Input() selected: any;
+  @Output() choose = new EventEmitter<any>();
+
+  styleValue = {
+    longitud: 'corto',
+    vocal_fuerte: false,
+    terminacion: 'a',
+    silabas: 1,
+  };
+
+  ngOnChanges() {
+    if (this.question?.type === 'style' && this.selected) {
+      this.styleValue = { ...this.styleValue, ...this.selected };
+    }
+  }
+
+  toggleMulti(id: string) {
+    const arr: string[] = Array.isArray(this.selected) ? [...this.selected] : [];
+    const idx = arr.indexOf(id);
+    if (idx >= 0) {
+      arr.splice(idx, 1);
+    } else if (!this.question?.maxSelection || arr.length < this.question.maxSelection) {
+      arr.push(id);
+    }
+    this.choose.emit(arr);
+  }
+
+  updateStyle(field: keyof typeof this.styleValue, value: string) {
+    if (field === 'vocal_fuerte') {
+      this.styleValue.vocal_fuerte = value === 'true';
+    } else if (field === 'silabas') {
+      this.styleValue.silabas = parseInt(value, 10) as 1 | 2 | 3;
+    } else {
+      this.styleValue[field] = value as any;
+    }
+    this.emitStyle();
+  }
+
+  emitStyle() {
+    this.choose.emit({ ...this.styleValue });
+  }
 }

--- a/src/app/test/services/quiz.service.ts
+++ b/src/app/test/services/quiz.service.ts
@@ -1,233 +1,134 @@
 import { Injectable } from '@angular/core';
 import { Question } from '../components/question-viewer.component';
+import { QuizProfile } from '../../shared/models/quiz-profile.model';
 
 @Injectable({ providedIn: 'root' })
 export class QuizService {
   questions: Question[] = [
     {
-      id: 'elemento',
-      title: '¿Qué elemento resuena más contigo?',
+      id: 'energia_simbolica',
+      title: '¿Qué tipo de energía sientes que rodea a este nuevo ser?',
+      type: 'multi',
+      maxSelection: 2,
       options: [
-        {
-          id: 'fuego', label: 'Fuego', icon: '🔥',
-          value: 1
-        },
-        {
-          id: 'agua', label: 'Agua', icon: '💧',
-          value: 2
-        },
-        {
-          id: 'aire', label: 'Aire', icon: '🌬️',
-          value: 3
-        },
-        {
-          id: 'tierra', label: 'Tierra', icon: '🌱',
-          value: 4
-        },
+        { id: 'luz', label: 'Luz', icon: '🌟' },
+        { id: 'magia', label: 'Magia', icon: '✨' },
+        { id: 'dulzura', label: 'Dulzura', icon: '🍯' },
+        { id: 'proteccion', label: 'Protección', icon: '🛡️' },
+        { id: 'sabiduria', label: 'Sabiduría', icon: '🧠' },
+        { id: 'fuego', label: 'Fuego', icon: '🔥' },
+        { id: 'rebeldia', label: 'Rebeldía', icon: '⚡' },
+        { id: 'calma', label: 'Calma', icon: '🕊️' },
+        { id: 'transformacion', label: 'Transformación', icon: '🌀' },
+        { id: 'espiritualidad', label: 'Espiritualidad', icon: '🌙' },
       ],
     },
     {
-      id: 'momento_dia',
-      title: 'Elige el momento del día que prefieres',
+      id: 'personalidad_proyectada',
+      title: '¿Qué cualidades deseas que este ser refleje?',
+      type: 'multi',
+      maxSelection: 3,
       options: [
-        {
-          id: 'amanecer', label: 'Amanecer', icon: '🌅',
-          value: 1
-        },
-        {
-          id: 'mediodia', label: 'Mediodía', icon: '🌞',
-          value: 2
-        },
-        {
-          id: 'atardecer', label: 'Atardecer', icon: '🌇',
-          value: 3
-        },
-        {
-          id: 'noche', label: 'Noche', icon: '🌙',
-          value: 4
-        },
+        { id: 'creativo', label: 'Creativo', icon: '🎨' },
+        { id: 'protector', label: 'Protector', icon: '🐻' },
+        { id: 'alegre', label: 'Alegre', icon: '😊' },
+        { id: 'sabio', label: 'Sabio', icon: '🦉' },
+        { id: 'libre', label: 'Libre', icon: '🌬️' },
+        { id: 'valiente', label: 'Valiente', icon: '🗡️' },
+        { id: 'misterioso', label: 'Misterioso', icon: '🌑' },
+        { id: 'compasivo', label: 'Compasivo', icon: '💞' },
+        { id: 'profundo', label: 'Profundo', icon: '🌊' },
       ],
     },
     {
-      id: 'flor',
-      title: '¿Qué flor te inspira más?',
+      id: 'estilo_sonoro',
+      title: '¿Cómo te gustaría que suene su nombre?',
+      type: 'style',
+    },
+    {
+      id: 'origen_simbolico',
+      title: '¿Qué raíces culturales te inspiran?',
+      type: 'multi',
+      maxSelection: 2,
       options: [
-        {
-          id: 'rosa', label: 'Rosa', icon: '🌹',
-          value: 1
-        },
-        {
-          id: 'lirio', label: 'Lirio', icon: '🌺',
-          value: 2
-        },
-        {
-          id: 'jazmin', label: 'Jazmín', icon: '🌼',
-          value: 3
-        },
-        {
-          id: 'loto', label: 'Loto', icon: '🪷',
-          value: 4
-        },
+        { id: 'andino', label: 'Andino', icon: '🏔️' },
+        { id: 'celta', label: 'Celta', icon: '🌀' },
+        { id: 'hebreo', label: 'Hebreo', icon: '✡️' },
+        { id: 'arabe', label: 'Árabe', icon: '🕌' },
+        { id: 'indigena', label: 'Indígena', icon: '🪶' },
+        { id: 'latino', label: 'Latino clásico', icon: '🏛️' },
+        { id: 'vasco', label: 'Vasco', icon: '🗻' },
+        { id: 'africano', label: 'Africano simbólico', icon: '🌍' },
+        { id: 'mapuche', label: 'Mapuche', icon: '🐾' },
+        { id: 'griego', label: 'Griego', icon: '🏺' },
       ],
     },
     {
-      id: 'sonido',
-      title: 'Escoge un sonido que armonice tu espíritu',
+      id: 'valores_deseados',
+      title: '¿Qué valores deseas transmitir a través del nombre?',
+      type: 'multi',
+      maxSelection: 3,
       options: [
-        {
-          id: 'olas', label: 'Olas del mar', icon: '🌊',
-          value: 1
-        },
-        {
-          id: 'lluvia', label: 'Lluvia suave', icon: '🌧️',
-          value: 2
-        },
-        {
-          id: 'viento', label: 'Viento entre árboles', icon: '🍃',
-          value: 3
-        },
-        {
-          id: 'campanas', label: 'Campanas tibetanas', icon: '🔔',
-          value: 4
-        },
+        { id: 'libertad', label: 'Libertad', icon: '🕊️' },
+        { id: 'conexion', label: 'Conexión', icon: '🔗' },
+        { id: 'resiliencia', label: 'Resiliencia', icon: '🌱' },
+        { id: 'renacimiento', label: 'Renacimiento', icon: '🔄' },
+        { id: 'sabiduria_valor', label: 'Sabiduría', icon: '📚' },
+        { id: 'sensibilidad', label: 'Sensibilidad', icon: '💧' },
+        { id: 'belleza', label: 'Belleza', icon: '🌸' },
+        { id: 'autenticidad', label: 'Autenticidad', icon: '🔥' },
       ],
     },
     {
-      id: 'cristal',
-      title: '¿Qué cristal llevarías contigo?',
+      id: 'genero_preferido',
+      title: '¿Tienes alguna preferencia de género?',
+      type: 'single',
       options: [
-        {
-          id: 'cuarzo', label: 'Cuarzo', icon: '💎',
-          value: 1
-        },
-        {
-          id: 'amatista', label: 'Amatista', icon: '🔮',
-          value: 2
-        },
-        {
-          id: 'obsidiana', label: 'Obsidiana', icon: '⚫',
-          value: 3
-        },
-        {
-          id: 'jade', label: 'Jade', icon: '🟢',
-          value: 4
-        },
+        { id: 'femenino', label: 'Femenino', icon: '🚺' },
+        { id: 'masculino', label: 'Masculino', icon: '🚹' },
+        { id: 'neutro', label: 'Neutro', icon: '⚧️' },
+        { id: 'sin_preferencia', label: 'Sin preferencia', icon: '❔' },
       ],
     },
     {
-      id: 'animal_guia',
-      title: 'Elige un animal guía',
+      id: 'inspiracion',
+      title: '¿Qué tipo de historia o energía quieres que inspire el nombre?',
+      type: 'combined',
       options: [
-        {
-          id: 'lobo', label: 'Lobo', icon: '🐺',
-          value: 1
-        },
-        {
-          id: 'gato', label: 'Gato', icon: '🐱',
-          value: 2
-        },
-        {
-          id: 'mariposa', label: 'Mariposa', icon: '🦋',
-          value: 3
-        },
-        {
-          id: 'lechuza', label: 'Lechuza', icon: '🦉',
-          value: 4
-        },
-      ],
-    },
-    {
-      id: 'aroma',
-      title: '¿Qué aroma calma tu mente?',
-      options: [
-        {
-          id: 'lavanda', label: 'Lavanda', icon: '💜',
-          value: 1
-        },
-        {
-          id: 'sandalwood', label: 'Sándalo', icon: '🪵',
-          value: 2
-        },
-        {
-          id: 'jazmin_aroma', label: 'Jazmín', icon: '🌸',
-          value: 3
-        },
-        {
-          id: 'cedro', label: 'Cedro', icon: '🌲',
-          value: 4
-        },
-      ],
-    },
-    {
-      id: 'camino',
-      title: 'Elige un camino para recorrer',
-      options: [
-        {
-          id: 'bosque', label: 'Bosque', icon: '🌳',
-          value: 1
-        },
-        {
-          id: 'montana', label: 'Montaña', icon: '⛰️',
-          value: 2
-        },
-        {
-          id: 'playa', label: 'Playa', icon: '🏖️',
-          value: 3
-        },
-        {
-          id: 'desierto', label: 'Desierto', icon: '🏜️',
-          value: 4
-        },
-      ],
-    },
-    {
-      id: 'estacion',
-      title: '¿Cuál estación del año prefieres?',
-      options: [
-        {
-          id: 'primavera', label: 'Primavera', icon: '🌷',
-          value: 1
-        },
-        {
-          id: 'verano', label: 'Verano', icon: '☀️',
-          value: 2
-        },
-        {
-          id: 'otono', label: 'Otoño', icon: '🍂',
-          value: 3
-        },
-        {
-          id: 'invierno', label: 'Invierno', icon: '❄️',
-          value: 4
-        },
-      ],
-    },
-    {
-      id: 'color',
-      title: 'Escoge el color que más conecte contigo',
-      options: [
-        {
-          id: 'rojo', label: 'Rojo', icon: '❤️',
-          value: 1
-        },
-        {
-          id: 'azul', label: 'Azul', icon: '💙',
-          value: 2
-        },
-        {
-          id: 'verde', label: 'Verde', icon: '💚',
-          value: 3
-        },
-        {
-          id: 'violeta', label: 'Violeta', icon: '💜',
-          value: 4
-        },
+        { id: 'mistico_antiguo', label: 'Antigua y mística', icon: '🧙‍♀️', tonePoetico: 'mistico', epocaInspiradora: 'antigua' },
+        { id: 'espiritual_naturaleza', label: 'Alma y naturaleza', icon: '🌿', tonePoetico: 'espiritual', epocaInspiradora: 'naturaleza' },
+        { id: 'moderno_futuro', label: 'Futura y visionaria', icon: '🔮', tonePoetico: 'moderno', epocaInspiradora: 'futuro' },
+        { id: 'atemporal_simple', label: 'Simple y eterno', icon: '⏳', tonePoetico: 'atemporal', epocaInspiradora: 'sin_tiempo_definido' },
       ],
     },
   ];
 
-  submitAnswers(answers: Record<string, string>) {
-    // Se podría enviar al backend. Aquí solo registramos en consola.
-    console.log('Enviando quizProfile', answers);
+  submitAnswers(answers: Record<string, any>) {
+    const profile: QuizProfile = {
+      energia_simbolica: answers['energia_simbolica'] || [],
+      personalidad_proyectada: answers['personalidad_proyectada'] || [],
+      estilo_sonoro: answers['estilo_sonoro'] || {
+        longitud: 'corto',
+        vocal_fuerte: false,
+        terminacion: 'a',
+        silabas: 1,
+      },
+      origen_simbolico: answers['origen_simbolico'] || [],
+      valores_deseados: answers['valores_deseados'] || [],
+      genero_preferido: answers['genero_preferido'] || 'sin_preferencia',
+      tono_poetico: '',
+      epoca_inspiradora: '',
+    };
+
+    const insp = answers['inspiracion'];
+    const opt = this.questions
+      .find(q => q.id === 'inspiracion')?.options
+      ?.find(o => o.id === insp);
+    if (opt) {
+      profile.tono_poetico = opt.tonePoetico || '';
+      profile.epoca_inspiradora = opt.epocaInspiradora || '';
+    }
+
+    console.log('Enviando quizProfile', profile);
   }
 }


### PR DESCRIPTION
## Summary
- define `QuizProfile` model
- extend question viewer to support single, multi, style, and combined questions
- update test page logic for new question types
- replace quiz service with emotional test data and results parser
- remove unused component imports and switch to `@if` syntax where needed
- replace `*ngSwitch` and `*ngIf` with Angular's new control flow and drop `FormsModule`

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng build` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_685f8e408994832aa3079f11c1ffe9ec