### PR TITLE
Improve question transitions

### DIFF
--- a/src/app/test/pages/test.page.ts
+++ b/src/app/test/pages/test.page.ts
@@ -22,11 +22,21 @@ import {
   animations: [
     trigger('questionFade', [
       transition(':enter', [
-        style({ opacity: 0, transform: 'translateY(20px)' }),
-        animate('400ms ease-out', style({ opacity: 1, transform: 'translateY(0)' })),
+        style({
+          opacity: 0,
+          transform: 'translateY(2rem) scale(0.96)',
+          filter: 'blur(1px)',
+        }),
+        animate(
+          '600ms cubic-bezier(.16,1,.3,1)',
+          style({ opacity: 1, transform: 'translateY(0) scale(1)', filter: 'blur(0)' })
+        ),
       ]),
       transition(':leave', [
-        animate('300ms ease-in', style({ opacity: 0, transform: 'translateY(-12px)' })),
+        animate(
+          '400ms cubic-bezier(.4,0,.2,1)',
+          style({ opacity: 0, transform: 'translateY(-12px)', filter: 'blur(0.5px)' })
+        ),
       ]),
     ]),
   ],

--- a/src/styles.css
+++ b/src/styles.css
@@ -180,4 +180,21 @@
   .animate-ethereal-entry {
     animation: ethereal-entry 0.6s ease-out both;
   }
+
+  @keyframes question-brand {
+    0% {
+      opacity: 0;
+      transform: translateY(2rem) scale(0.96);
+      filter: blur(1px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      filter: blur(0);
+    }
+  }
+
+  .animate-question-brand {
+    animation: question-brand 0.6s cubic-bezier(.16,1,.3,1) both;
+  }
 }


### PR DESCRIPTION
## Summary
- customize questionFade animation for smoother transition
- add `question-brand` keyframes for brand look

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcab5a06c832a9761ea5a31be9c88