### PR TITLE
Add progressive reveal results page

### DIFF
--- a/src/app/result/components/nombre-revelado.component.ts
+++ b/src/app/result/components/nombre-revelado.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'ui-nombre-revelado',
+  template: `
+    <article
+      class="relative rounded-2xl px-6 py-8 shadow-xl transition-all duration-500 max-w-2xl mx-auto
+              border border-base-300 bg-base-100/90 text-center overflow-hidden"
+      [class.border-amber-400]="esIA"
+      [class.shadow-amber-300/40]="esIA"
+    >
+      @if (esIA) {
+        <div class="absolute top-0 left-1/2 -translate-x-1/2 w-72 h-72 bg-yellow-400/10 blur-[80px] rounded-full z-0 pointer-events-none animate-pulse-slower"></div>
+        <div class="absolute top-3 right-3 text-xs font-semibold text-yellow-500 tracking-wide flex items-center gap-1 animate-fade-in">
+          ✦ Nombre generado por IA
+        </div>
+      }
+
+      <div class="relative z-10">
+        <h3 class="text-4xl font-serif text-primary mb-2 tracking-tight">{{ nombre }}</h3>
+        <p class="italic text-base-content/70 mb-3 text-lg">“{{ significado }}”</p>
+        <div class="text-pink-500 text-xl font-medium mb-4">{{ simbolo }}</div>
+
+        <div class="text-sm space-y-2 text-base-content/80 leading-relaxed max-w-md mx-auto">
+          <p><strong>Numerología:</strong> {{ numerologia }}</p>
+          <p><strong>Conexión histórica:</strong> {{ famosos }}</p>
+        </div>
+      </div>
+    </article>
+  `,
+  styles: [`
+    @keyframes pulse-slower {
+      0%, 100% { opacity: 0.25; transform: scale(1); }
+      50% { opacity: 0.5; transform: scale(1.05); }
+    }
+    .animate-pulse-slower {
+      animation: pulse-slower 6s ease-in-out infinite;
+    }
+  `],
+})
+export class NombreReveladoComponent {
+  @Input() nombre = '';
+  @Input() significado = '';
+  @Input() simbolo = '';
+  @Input() numerologia = '';
+  @Input() famosos = '';
+  @Input() esIA = false;
+}

--- a/src/app/result/pages/results-final.page.ts
+++ b/src/app/result/pages/results-final.page.ts
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+import { NombreReveladoComponent } from '../components/nombre-revelado.component';
+import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
+
+@Component({
+  standalone: true,
+  selector: 'app-results-final-page',
+  imports: [NombreReveladoComponent, RevealOnScrollDirective],
+  template: `
+    <section class="px-4 py-20 max-w-3xl mx-auto text-center">
+      <header class="mb-16 animate-fade-in-up">
+        <h2 class="text-4xl font-serif text-primary tracking-tight">
+          🌟 Has desbloqueado nombres con alma única
+        </h2>
+        <p class="mt-3 text-base italic text-base-content/70 max-w-lg mx-auto">
+          Cada nombre refleja una energía especial y fue elegido para ti.
+        </p>
+      </header>
+
+      <div class="space-y-16">
+        <ui-nombre-revelado
+          *ngFor="let n of nombres; trackBy: trackNombre"
+          [nombre]="n.nombre"
+          [significado]="n.significado"
+          [simbolo]="n.simbolo"
+          [numerologia]="n.numerologia"
+          [famosos]="n.famosos"
+          [esIA]="n.esIA"
+          appRevealOnScroll
+        />
+      </div>
+    </section>
+  `,
+})
+export class ResultsFinalPage {
+  nombres = [
+    {
+      nombre: 'Aurelia',
+      significado: 'Aquella que brilla con luz dorada',
+      simbolo: '🌞 Sol espiritual',
+      numerologia: '7 – Sabiduría interior y visión',
+      famosos: 'Aurelia Plath (madre de Sylvia Plath), símbolo de inspiración materna',
+      esIA: false,
+    },
+    {
+      nombre: 'Selene',
+      significado: 'La que danza bajo la luna',
+      simbolo: '🌙 Espíritu lunar',
+      numerologia: '9 – Sensibilidad elevada y alma universal',
+      famosos: 'Diosa griega de la luna, musa de artistas',
+      esIA: true,
+    },
+    {
+      nombre: 'Naela',
+      significado: 'La que trae bendiciones',
+      simbolo: '🌿 Pureza espiritual',
+      numerologia: '6 – Protección, armonía familiar y belleza interior',
+      famosos: 'Relacionado con raíces árabes, significado maternal y de sanación',
+      esIA: true,
+    },
+  ];
+
+  trackNombre(_: number, item: { nombre: string }) {
+    return item.nombre;
+  }
+}

--- a/src/app/routes/app.routes.ts
+++ b/src/app/routes/app.routes.ts
@@ -19,6 +19,10 @@ export const appRoutes: Routes = [
         loadComponent: () => import('../result/pages/result.page').then(m => m.ResultPageComponent),
       },
       {
+        path: 'results-final',
+        loadComponent: () => import('../result/pages/results-final.page').then(m => m.ResultsFinalPage),
+      },
+      {
         path: 'pay',
         loadComponent: () => import('../pay/pages/payment-redirect.page').then(m => m.PaymentRedirectPage),
       },

--- a/src/app/shared/directives/reveal-on-scroll.directive.ts
+++ b/src/app/shared/directives/reveal-on-scroll.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, ElementRef, OnDestroy } from '@angular/core';
+
+@Directive({
+  selector: '[appRevealOnScroll]',
+  standalone: true,
+})
+export class RevealOnScrollDirective implements OnDestroy {
+  private observer: IntersectionObserver;
+
+  constructor(private el: ElementRef<HTMLElement>) {
+    this.observer = new IntersectionObserver(
+      entries => {
+        const [entry] = entries;
+        if (entry.isIntersecting) {
+          this.el.nativeElement.classList.add('animate-fade-in-up');
+          this.el.nativeElement.classList.remove('opacity-0');
+          this.observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    this.el.nativeElement.classList.add('opacity-0');
+    this.observer.observe(this.el.nativeElement);
+  }
+
+  ngOnDestroy() {
+    this.observer.disconnect();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `NombreReveladoComponent` for detailed name cards
- add `ResultsFinalPage` with scroll reveal animations
- create `RevealOnScrollDirective` for IntersectionObserver-based fade in
- register new route `/results-final`

## Testing
- `npx ng test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68609dcf4fb8832aad6e8de0aa99230a