### PR TITLE
Add payment failure page

### DIFF
--- a/src/app/pay/pages/payment-failure.page.ts
+++ b/src/app/pay/pages/payment-failure.page.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { PrimaryButtonComponent } from '../../shared/components';
+
+@Component({
+  standalone: true,
+  selector: 'app-payment-failure-page',
+  imports: [RouterModule, PrimaryButtonComponent],
+  template: `
+    <section class="py-24 px-4 text-center relative">
+      <div
+        class="absolute left-1/2 -translate-x-1/2 top-12 w-96 h-96 bg-error/10 blur-[100px] rounded-full pointer-events-none"
+        aria-hidden="true"
+      ></div>
+
+      <h2 class="text-3xl font-serif mb-4 text-error tracking-tight animate-fade-in-up">
+        Tu pago no pudo completarse
+      </h2>
+      <p class="text-base font-sans text-base-content/70 italic mb-8 animate-fade-in delay-200">
+        Ocurrió un problema al procesar la transacción.
+      </p>
+
+      <ui-primary-button routerLink="/purchase" class="animate-fade-in-up delay-300">
+        Intentar nuevamente
+      </ui-primary-button>
+
+      <p class="text-sm text-base-content/50 mt-6 animate-fade-in delay-500">
+        Si el inconveniente persiste, por favor contáctanos.
+      </p>
+    </section>
+  `,
+})
+export class PaymentFailurePage {}

--- a/src/app/routes/app.routes.ts
+++ b/src/app/routes/app.routes.ts
@@ -30,6 +30,10 @@ export const appRoutes: Routes = [
         path: 'payment/redirect',
         loadComponent: () => import('../pay/pages/payment-redirect.page').then(m => m.PaymentRedirectPage),
       },
+      {
+        path: 'payment/failure',
+        loadComponent: () => import('../pay/pages/payment-failure.page').then(m => m.PaymentFailurePage),
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- add a standalone page to show when a payment fails
- wire the payment failure page into the app routes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862933a64e4832a9ef652b3d02db10d